### PR TITLE
Removed TODO's

### DIFF
--- a/core/require.js
+++ b/core/require.js
@@ -1,7 +1,5 @@
 'use strict';
 
-//TODO: expand module with plausibilty to add your own packages.
-
 const _ = require('lodash');
 const Module = require('module');
 const config = require('./config');
@@ -27,7 +25,6 @@ class Require {
         if(module && _.isArray(module)) {
           let getters = [Hammer.modules, Hammer.plugins.get];
 
-          //TODO: also add the plausibility for setters
           return new Proxy({}, {
             get: function(func, name) {
               for(let i=0;i<getters.length;i++) {


### PR DESCRIPTION
TODO: expand module with plausibilty to add your own packages.
This can be done by creating a plugin.

TODO: also add the plausibility for setters
This has been added in commit 0e7db6f