### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/core/authentication.js
+++ b/core/authentication.js
@@ -2,7 +2,7 @@
 
 //TODO: add passport to Authentication to support for example facebook, google, github, and twitter login
 
-const uuid      = require('node-uuid');
+const uuid      = require('uuid');
 const bcrypt    = require('bcryptjs');
 const config    = require('./config');
 const database  = require('./database');

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "mime": "^1.3.4",
     "moment": "^2.15.1",
     "node-emoji": "^1.4.1",
-    "node-uuid": "^1.4.7",
     "promised-handlebars": "^2.0.1",
     "semver": "^5.3.0",
-    "sqlite3": "3.1.4"
+    "sqlite3": "3.1.4",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.